### PR TITLE
Fix typo in the_rules: mages -> images

### DIFF
--- a/_the_law/the-rules.md
+++ b/_the_law/the-rules.md
@@ -49,7 +49,7 @@ if you want to try out chat features!**
 * You can inline images (URL must end with a recognisable image extension). Animated GIFs are likely to be binned.
 * Do not link to not-work-safe materials without appropriate warning. You might get kicked despite the warning though, depending on the nature of the link.
 * Under no circumstances ever inline not-work-safe materials. You *will* be kicked.
-* You can upload and immediately inline mages using the "upload" button. (They will be uploaded to Stack Exchange's instance of Imgur).
+* You can upload and immediately inline images using the "upload" button. (They will be uploaded to Stack Exchange's instance of Imgur).
 
 ### Code
 


### PR DESCRIPTION
Inlining images may or may not be wizardry, but I don't think that's what was intended ;)